### PR TITLE
Add customer transfer APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,54 @@ for row in user_list:
 ```
 
 ### 20240617 更新
+新增获客链接接口封装：
 
-https://developer.work.weixin.qq.com/document/path/97297#%E8%8E%B7%E5%8F%96%E8%8E%B7%E5%AE%A2%E9%93%BE%E6%8E%A5%E5%88%97%E8%A1%A8
-https://developer.work.weixin.qq.com/document/path/97297#%E8%8E%B7%E5%8F%96%E8%8E%B7%E5%AE%A2%E9%93%BE%E6%8E%A5%E8%AF%A6%E6%83%85
-https://developer.work.weixin.qq.com/document/path/97375#%E6%9F%A5%E8%AF%A2%E9%93%BE%E6%8E%A5%E4%BD%BF%E7%94%A8%E8%AF%A6%E6%83%85
+- `customer_acquisition.list_link` - 获取获客链接列表
+- `customer_acquisition.get` - 获取获客链接详情
+- `customer_acquisition.create_link` - 创建获客链接
+- `customer_acquisition.update_link` - 更新获客链接
+- `customer_acquisition.delete_link` - 删除获客链接
+- `customer_acquisition_quota.get_quota` - 查询剩余使用量
+- `customer_acquisition_quota.statistic` - 查询链接使用详情
+
+接口文档参考：
+https://developer.work.weixin.qq.com/document/path/97297
+https://developer.work.weixin.qq.com/document/path/97375
+
+### 20240619 新增
+新增客户群管理接口：
+
+- `groupchat.list` - 获取客户群列表
+- `groupchat.get` - 获取客户群详情
+- `groupchat.add_join_way` - 创建群链接
+- `groupchat.get_join_way` - 获取群链接详情
+- `groupchat.update_join_way` - 更新群链接
+- `groupchat.del_join_way` - 删除群链接
+
+接口文档参考：
+https://developer.work.weixin.qq.com/document/path/92120
+
+### 20240620 新增
+新增欢迎语和群欢迎语接口：
+
+- `customer.send_welcome_msg` - 发送新客户欢迎语
+- `group_welcome_template.add` - 创建群欢迎语模板
+- `group_welcome_template.edit` - 编辑群欢迎语模板
+- `group_welcome_template.get` - 获取群欢迎语模板详情
+- `group_welcome_template.delete` - 删除群欢迎语模板
+
+接口文档参考：
+https://developer.work.weixin.qq.com/document/path/92134
+
+### 20240621 新增
+新增客户和群聊继承接口：
+
+- `customer.transfer_customer` - 在职成员分配客户
+- `customer.transfer_result` - 查询客户分配结果
+- `customer.resigned_transfer_customer` - 离职成员客户继承
+- `customer.resigned_transfer_result` - 查询离职客户继承结果
+- `groupchat.transfer` - 离职成员群聊继承
+- `groupchat.transfer_result` - 查询群聊继承结果
+
+接口文档参考：
+https://developer.work.weixin.qq.com/document/path/92125

--- a/README.md
+++ b/README.md
@@ -171,3 +171,14 @@ https://developer.work.weixin.qq.com/document/path/92134
 
 接口文档参考：
 https://developer.work.weixin.qq.com/document/path/92125
+
+### 20240622 新增
+新增电子发票接口封装：
+
+- `invoice.get_invoice_info` - 查询单张电子发票
+- `invoice.get_invoice_info_batch` - 批量查询电子发票
+- `invoice.update_invoice_status` - 更新单张发票状态
+- `invoice.update_invoice_status_batch` - 批量更新发票状态
+
+接口文档参考：
+https://developer.work.weixin.qq.com/document/path/90664

--- a/pywxwork/customer/customer.py
+++ b/pywxwork/customer/customer.py
@@ -189,3 +189,83 @@ class customer(base):
         params = {"strategy_id": strategy_id}
         response = self.request(api_name=api_name, json=params, method="post")
         return response
+
+    def send_welcome_msg(self, data):
+        """发送新客户欢迎语"""
+        api_name = "externalcontact/send_welcome_msg"
+        response = self.request(api_name=api_name, method="post", json=data)
+        return response
+
+    def transfer_customer(
+        self,
+        external_userid: list,
+        handover_userid: str,
+        takeover_userid: str,
+        transfer_success_msg: bool = True,
+    ):
+        """在职成员分配客户"""
+        api_name = "externalcontact/transfer_customer"
+        data = {
+            "external_userid": external_userid,
+            "handover_userid": handover_userid,
+            "takeover_userid": takeover_userid,
+            "transfer_success_msg": transfer_success_msg,
+        }
+        response = self.request(api_name=api_name, method="post", json=data)
+        return response
+
+    def transfer_result(
+        self,
+        handover_userid: str,
+        takeover_userid: str,
+        cursor: str = None,
+        limit: int = 100,
+    ):
+        """查询在职成员分配结果"""
+        api_name = "externalcontact/transfer_result"
+        data = {
+            "handover_userid": handover_userid,
+            "takeover_userid": takeover_userid,
+            "limit": limit,
+        }
+        if cursor:
+            data["cursor"] = cursor
+        response = self.request(api_name=api_name, method="post", json=data)
+        return response
+
+    def resigned_transfer_customer(
+        self,
+        external_userid: list,
+        handover_userid: str,
+        takeover_userid: str,
+        transfer_success_msg: bool = True,
+    ):
+        """离职成员客户继承"""
+        api_name = "externalcontact/resigned/transfer_customer"
+        data = {
+            "external_userid": external_userid,
+            "handover_userid": handover_userid,
+            "takeover_userid": takeover_userid,
+            "transfer_success_msg": transfer_success_msg,
+        }
+        response = self.request(api_name=api_name, method="post", json=data)
+        return response
+
+    def resigned_transfer_result(
+        self,
+        handover_userid: str,
+        takeover_userid: str,
+        cursor: str = None,
+        limit: int = 100,
+    ):
+        """查询离职成员客户继承结果"""
+        api_name = "externalcontact/resigned/transfer_result"
+        data = {
+            "handover_userid": handover_userid,
+            "takeover_userid": takeover_userid,
+            "limit": limit,
+        }
+        if cursor:
+            data["cursor"] = cursor
+        response = self.request(api_name=api_name, method="post", json=data)
+        return response

--- a/pywxwork/externalcontact/__init__.py
+++ b/pywxwork/externalcontact/__init__.py
@@ -1,5 +1,12 @@
 from .customer_acquisition import customerAcquisition
 from .customer_acquisition_quota import customerAcquisitionQuota
+from .groupchat import groupChat
+from .group_welcome_template import groupWelcomeTemplate
 
 # 导出模块
-__all__ = ["customerAcquisition", "customerAcquisitionQuota"]
+__all__ = [
+    "customerAcquisition",
+    "customerAcquisitionQuota",
+    "groupChat",
+    "groupWelcomeTemplate",
+]

--- a/pywxwork/externalcontact/customer_acquisition/__init__.py
+++ b/pywxwork/externalcontact/customer_acquisition/__init__.py
@@ -27,31 +27,14 @@ class customerAcquisition(base):
         response = self.request(api_name=api_name, method="post", json=data)
         return response
 
-    def create_link(self, link_id):
-        api_name = "externalcontact/customer_acquisition/list_link"
-        data = {
-            "link_name": "获客链接1号",
-            "range": {"user_list": ["zhangsan", "lisi"], "department_list": [2, 3]},
-            "skip_verify": True,
-            "priority_option": {
-                "priority_type": 2,
-                "priority_userid_list": ["tom", "lisi"],
-            },
-        }
+    def create_link(self, data):
+        """创建获客链接"""
+        api_name = "externalcontact/customer_acquisition/create_link"
         response = self.request(api_name=api_name, method="post", json=data)
         return response
 
-    def update_link(self):
-        api_name = "externalcontact/customer_acquisition/list_link"
-        data = {
-            "link_id": "LINK_ID",
-            "link_name": "获客链接1号",
-            "range": {"user_list": ["zhangsan", "lisi"], "department_list": [2, 3]},
-            "skip_verify": True,
-            "priority_option": {
-                "priority_type": 2,
-                "priority_userid_list": ["tom", "lisi"],
-            },
-        }
+    def update_link(self, data):
+        """更新获客链接"""
+        api_name = "externalcontact/customer_acquisition/update_link"
         response = self.request(api_name=api_name, method="post", json=data)
         return response

--- a/pywxwork/externalcontact/customer_acquisition_quota/__init__.py
+++ b/pywxwork/externalcontact/customer_acquisition_quota/__init__.py
@@ -9,46 +9,6 @@ class customerAcquisitionQuota(base):
         """
         super().__init__(token)
 
-    def get(self, link_id):
-        api_name = "externalcontact/customer_acquisition/get"
-        data = {"link_id": link_id}
-        response = self.request(api_name=api_name, method="post", json=data)
-        return response
-
-    def delete_link(self, link_id):
-        api_name = "externalcontact/customer_acquisition/delete_link"
-        data = {"link_id": link_id}
-        response = self.request(api_name=api_name, method="post", json=data)
-        return response
-
-    def create_link(self, link_id):
-        api_name = "externalcontact/customer_acquisition/list_link"
-        data = {
-            "link_name": "获客链接1号",
-            "range": {"user_list": ["zhangsan", "lisi"], "department_list": [2, 3]},
-            "skip_verify": True,
-            "priority_option": {
-                "priority_type": 2,
-                "priority_userid_list": ["tom", "lisi"],
-            },
-        }
-        response = self.request(api_name=api_name, method="post", json=data)
-        return response
-
-    def update_link(self):
-        api_name = "externalcontact/customer_acquisition/list_link"
-        data = {
-            "link_id": "LINK_ID",
-            "link_name": "获客链接1号",
-            "range": {"user_list": ["zhangsan", "lisi"], "department_list": [2, 3]},
-            "skip_verify": True,
-            "priority_option": {
-                "priority_type": 2,
-                "priority_userid_list": ["tom", "lisi"],
-            },
-        }
-        response = self.request(api_name=api_name, method="post", json=data)
-        return response
 
     # 查询剩余使用量
     def get_quota(self):

--- a/pywxwork/externalcontact/group_welcome_template/__init__.py
+++ b/pywxwork/externalcontact/group_welcome_template/__init__.py
@@ -1,0 +1,27 @@
+from ...base import base
+from loguru import logger
+
+
+class groupWelcomeTemplate(base):
+    """客户群欢迎语管理"""
+
+    def __init__(self, token: str):
+        super().__init__(token)
+
+    def add(self, data):
+        api_name = "externalcontact/group_welcome_template/add"
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def edit(self, data):
+        api_name = "externalcontact/group_welcome_template/edit"
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def get(self, template_id):
+        api_name = "externalcontact/group_welcome_template/get"
+        data = {"template_id": template_id}
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def delete(self, template_id):
+        api_name = "externalcontact/group_welcome_template/del"
+        data = {"template_id": template_id}
+        return self.request(api_name=api_name, method="post", json=data)

--- a/pywxwork/externalcontact/groupchat/__init__.py
+++ b/pywxwork/externalcontact/groupchat/__init__.py
@@ -1,0 +1,67 @@
+from ...base import base
+from loguru import logger
+
+
+class groupChat(base):
+    """客户群管理"""
+
+    def __init__(self, token: str):
+        super().__init__(token)
+
+    def list(self, status_filter=0, owner=None, limit=100, cursor=None):
+        api_name = "externalcontact/groupchat/list"
+        data = {
+            "status_filter": status_filter,
+            "limit": limit,
+        }
+        if owner:
+            data["owner"] = owner
+        if cursor:
+            data["cursor"] = cursor
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def get(self, chat_id, need_name=0):
+        api_name = "externalcontact/groupchat/get"
+        data = {"chat_id": chat_id, "need_name": need_name}
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def add_join_way(self, data):
+        api_name = "externalcontact/groupchat/add_join_way"
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def get_join_way(self, config_id):
+        api_name = "externalcontact/groupchat/get_join_way"
+        data = {"config_id": config_id}
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def update_join_way(self, data):
+        api_name = "externalcontact/groupchat/update_join_way"
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def del_join_way(self, config_id):
+        api_name = "externalcontact/groupchat/del_join_way"
+        data = {"config_id": config_id}
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def transfer(self, chat_id_list: list, new_owner: str):
+        api_name = "externalcontact/groupchat/transfer"
+        data = {
+            "chat_id_list": chat_id_list,
+            "new_owner": new_owner,
+        }
+        return self.request(api_name=api_name, method="post", json=data)
+
+    def transfer_result(
+        self,
+        status_filter: int = 2,
+        cursor: str = None,
+        limit: int = 100,
+    ):
+        api_name = "externalcontact/groupchat/transfer_result"
+        data = {
+            "status_filter": status_filter,
+            "limit": limit,
+        }
+        if cursor:
+            data["cursor"] = cursor
+        return self.request(api_name=api_name, method="post", json=data)

--- a/pywxwork/invoice/__init__.py
+++ b/pywxwork/invoice/__init__.py
@@ -13,6 +13,14 @@ class invoice(base):
 
         return response
 
+    def get_invoice_info_batch(self, item_list):
+        """批量查询电子发票信息"""
+        api_name = "card/invoice/reimburse/getinvoiceinfobatch"
+        data = {"item_list": item_list}
+        response = self.request(api_name=api_name, method="post", json=data)
+
+        return response
+
     def update_invoice_status(self, card_id, encrypt_code, reimburse_status):
         """
         发报销状态


### PR DESCRIPTION
## Summary
- document customer & group chat transfer endpoints in README
- implement customer transfer methods for active and resigned users
- support group chat transfer APIs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68536d02207c832fb6bc90262a1527d0